### PR TITLE
Bugfix release 0.2.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -251,14 +251,14 @@ zookeeper = ["kazoo (>=2.8.0)"]
 
 [[package]]
 name = "openrelik-worker-common"
-version = "0.11.0"
+version = "0.12.0"
 description = "Common utilities for OpenRelik workers"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openrelik_worker_common-0.11.0-py3-none-any.whl", hash = "sha256:fc196dab2faafa5f638764e1866ea3843d25858d934877fbbe74f03ab4911de9"},
-    {file = "openrelik_worker_common-0.11.0.tar.gz", hash = "sha256:aa4bd92d8ac21b03776f71d1801deeddc436ad05dcf4bd004b60ce23085f2821"},
+    {file = "openrelik_worker_common-0.12.0-py3-none-any.whl", hash = "sha256:d4190a8c193d3919e00b3255d6113b6832cf802286564e73e548b486529fb0a9"},
+    {file = "openrelik_worker_common-0.12.0.tar.gz", hash = "sha256:78629182cfaabb93ca246f4b13a657b9df0ce3c79c5575221f4f4a1cc86e81a4"},
 ]
 
 [package.dependencies]
@@ -364,4 +364,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "e5222ca0ba0ba23103d6826fb5ef8f467961f8cd8757ea6a798045c4cf53b5ae"
+content-hash = "fbeef782dec02ad81e20306e7ccc1d73ccad5b1effa15277634a6d79e767148f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openrelik-worker-strings"
-version = "0.2.0"
+version = "0.2.1"
 description = "Extract strings from files"
 authors = ["Johan Berggren <jberggren@gmail.com>"]
 license = "Apache 2.0"
@@ -10,7 +10,7 @@ package-mode = false
 [tool.poetry.dependencies]
 python = "^3.10"
 celery = { extras = ["redis"], version = "^5.4.0" }
-openrelik-worker-common = "^0.11.0"
+openrelik-worker-common = "^0.12.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -88,7 +88,7 @@ def strings(
     input_files = get_input_files(pipe_result, input_files or [])
     output_files = []
 
-    for encoding_name in task_config.items():
+    for encoding_name, unused_encoding_enabled in task_config.items():
         if encoding_name not in StringsEncoding.__members__:
             raise RuntimeError(f"{encoding_name} is not a valid StringsEncoding name")
 


### PR DESCRIPTION
### Summary:
Updated the `openrelik-worker-common` dependency to version 0.12.0 and corrected an iteration issue in the `strings` task.

### Technical Details:
*   **Dependency Update:** The `openrelik-worker-common` dependency was bumped from version 0.11.0 to 0.12.0 in `pyproject.toml`. This change requires a corresponding update in `poetry.lock` to reflect the new dependency version and its associated metadata.
*   **Task Configuration Fix:** The `strings` task in `src/tasks.py` had an issue with how it was iterating through the `task_config`. The code was changed to properly unpack the encoding name and a flag if encoding is enabled.
*   **Version Bump:** Incremented the package version from 0.2.0 to 0.2.1 in `pyproject.toml`.